### PR TITLE
Bumped emblem to ^0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "broccoli-filter": "^0.1.11",
-    "emblem": "^0.5.0",
+    "emblem": "^0.6.0",
     "ember-cli-version-checker": "^1.0.2",
     "lodash": "^3.6.0"
   }


### PR DESCRIPTION
Emblem compiler no longer outputs {{bind-attr}}, but requires Ember >= 1.11.