### PR TITLE
Update to emblem@^0.7.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-emblem",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "An ember-cli addon for Emblem.js templates.",
   "directories": {
     "doc": "doc",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "broccoli-filter": "^1.2.2",
     "ember-cli-version-checker": "^1.0.2",
-    "emblem": "^0.6.1",
+    "emblem": "^0.7.0",
     "lodash": "^3.6.0"
   }
 }


### PR DESCRIPTION
Update to emblem@`^0.7.0`, from `^0.6.1`. It should be compatible per semver, and the tests here are still passing.
Diff: https://github.com/machty/emblem.js/compare/0.6.1...0.7.1

There seems to be a `0.7.1` version as well, though it seems @machty hasn't published that to npm yet, but it will be included in the semver range when they do.
Diff: https://github.com/machty/emblem.js/compare/0.7.0...0.7.1

