### PR TITLE
fix #32: extra slash in tests

### DIFF
--- a/blueprints/component/index.js
+++ b/blueprints/component/index.js
@@ -1,5 +1,15 @@
 module.exports = {
   description: 'Generates a component. Name must contain a hyphen.',
+  availableOptions: [
+    {
+      name: 'path',
+      type: String,
+      default: 'components',
+      aliases:[
+        {'no-path': ''}
+      ]
+    }
+  ],
   locals: function(options) {
     return this.lookupBlueprint('component').locals(options);
   },


### PR DESCRIPTION
The default setting for the `path` option was missing.

Lines were copied straight from the [ember-cli blueprint](https://github.com/ember-cli/ember-cli/blob/master/blueprints/component/index.js#L14-L23).

Fixes #32.