### PR TITLE
Update to lodash 4.17.4 to avoid npm deprecation warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,6 @@
     "ember-cli-version-checker": "^1.0.2",
     "ember-cli-legacy-blueprints": "^0.1.1",
     "emblem": "^0.8.1",
-    "lodash": "^3.6.0"
+    "lodash": "^4.17.4"
   }
 }


### PR DESCRIPTION
Nuff said.